### PR TITLE
Remove upper boundaries from requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,9 @@
-requests>=0.10,<3.0.0
-six>=1.0.0,<2.0.0
-wheel==0.38.0
-boto==2.48.0
-python-dateutil>=2.6.1,<3.0.0
-diskcache>=2.9.0,<3.0.0
+requests>=0.10
+six>=1.0.0
+wheel>=0.38.0
+boto>=2.48.0
+python-dateutil>=2.6.1
+diskcache>=2.9.0
 setuptools>=65.5.1
-attrs>=18.1.0,<19.0.0
-trans>=2.1.0,<3.0.0
+attrs>=18.1.0
+trans>=2.1.0


### PR DESCRIPTION
I'm using imdbpie in combination with other libraries packaged inside my application.
However, the upper boundaries on the requirements are too strict and preventing me to install the newer versions.

Removing the upper boundaries in the requirements solves the issue.
In case a newer version should have issues again, we can always put back an upper boundary for that library.