### PR TITLE
IMDb have both 7 and 8 digit titles tt and soon actor nm

### DIFF
--- a/src/imdbpie/imdbpie.py
+++ b/src/imdbpie/imdbpie.py
@@ -331,7 +331,7 @@ class Imdb(Auth):
                 )
                 returned_id = resource['base'].get('id', '')
                 if returned_id:
-                    match = re.search(r'nm\d{7}', returned_id)
+                    match = re.search(r'nm\d{7,8}', returned_id)
                     if match:
                         actual_id = match.group()
                         # If the returned ID differs, it's a redirection
@@ -351,7 +351,7 @@ class Imdb(Auth):
                 )
                 returned_id = resource.get('id', '')
                 if returned_id:
-                    match = re.search(r'tt\d{7}', returned_id)
+                    match = re.search(r'tt\d{7,8}', returned_id)
                     if match:
                         actual_id = match.group()
                         # If the returned ID differs, it's a redirection


### PR DESCRIPTION
add the extra digit to the regex for tt and nm (no doubt in the future)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved IMDb ID matching to correctly recognize redirection results with 7- or 8-digit person and title IDs.
  * This helps prevent missed matches when IMDb returns longer ID values than before.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->