### PR TITLE
Update regex to allow 8-digit IMDb IDs

### DIFF
--- a/src/imdbpie/facade.py
+++ b/src/imdbpie/facade.py
@@ -17,7 +17,7 @@ from .objects import (
     NameSearchResult,
 )
 
-REGEX_IMDB_ID = re.compile(r'([a-zA-Z]{2}[0-9]{7})')
+REGEX_IMDB_ID = re.compile(r'([a-zA-Z]{2}[0-9]{7,8})')
 
 
 class ImdbFacade(object):

--- a/src/imdbpie/imdbpie.py
+++ b/src/imdbpie/imdbpie.py
@@ -269,7 +269,7 @@ class Imdb(Auth):
 
     @staticmethod
     def validate_imdb_id(imdb_id):
-        match_id = r'[a-zA-Z]{2}[0-9]{7}'
+        match_id = r'[a-zA-Z]{2}[0-9]{7,8}'
         try:
             re.match(match_id, imdb_id, re.IGNORECASE).group()
         except (AttributeError, TypeError):


### PR DESCRIPTION
Missed one of the {7} replacements.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved IMDb ID handling by accepting valid identifiers with two-letter prefixes followed by 7 or 8 digits.
  * This enhances compatibility and ensures IDs are correctly recognized when entered in different valid formats.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->